### PR TITLE
Small fixes for Fridai zone system.

### DIFF
--- a/src/movement.cpp
+++ b/src/movement.cpp
@@ -390,7 +390,7 @@ MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType, slots_t slot)
 	return nullptr;
 }
 
-MoveEvent* MoveEvents::getEvent(const Tile* tile, Item* item, MoveEvent_t eventType)
+MoveEvent* MoveEvents::getEvent(Item* item, MoveEvent_t eventType)
 {
 	MoveListMap::iterator it;
 
@@ -455,7 +455,7 @@ MoveEvent* MoveEvents::getEvent(const Tile* tile, MoveEvent_t eventType)
 	return nullptr;
 }
 
-std::vector<MoveEventList*> MoveEvents::getEvents(const Tile* tile, MoveEvent_t eventType)
+std::vector<MoveEventList*> MoveEvents::getEvents(const Tile* tile)
 {
 	std::vector<MoveEventList*> eventLists;
 
@@ -481,10 +481,10 @@ uint32_t MoveEvents::onCreatureMove(Creature* creature, const Tile* tile, MoveEv
 
 	const auto& zoneIds = tile->getZoneIds();
 	if (!zoneIds.empty()) {
-		std::vector<MoveEventList*> moveEventsLists = getEvents(tile, eventType);
+		std::vector<MoveEventList*> moveEventsLists = getEvents(tile);
 		for (auto moveEventList : moveEventsLists) {
 			if (moveEventList) {
-				uint32_t zoneId = moveEventList->zoneId;
+				uint16_t zoneId = moveEventList->zoneId;
 				for (MoveEvent& moveEvent : moveEventList->moveEvent[eventType]) {
 					ret &= moveEvent.fireStepEvent(creature, nullptr, pos, zoneId);
 				}
@@ -503,7 +503,7 @@ uint32_t MoveEvents::onCreatureMove(Creature* creature, const Tile* tile, MoveEv
 			continue;
 		}
 
-		moveEvent = getEvent(tile, tileItem, eventType);
+		moveEvent = getEvent(tileItem, eventType);
 		if (moveEvent) {
 			ret &= moveEvent->fireStepEvent(creature, tileItem, pos, 0);
 		}
@@ -547,7 +547,7 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
 		ret &= moveEvent->fireAddRemItem(item, nullptr, tile->getPosition());
 	}
 
-	moveEvent = getEvent(tile, item, eventType1);
+	moveEvent = getEvent(item, eventType1);
 	if (moveEvent) {
 		ret &= moveEvent->fireAddRemItem(item, nullptr, tile->getPosition());
 	}
@@ -563,7 +563,7 @@ uint32_t MoveEvents::onItemMove(Item* item, Tile* tile, bool isAdd)
 			continue;
 		}
 
-		moveEvent = getEvent(tile, tileItem, eventType2);
+		moveEvent = getEvent(tileItem, eventType2);
 		if (moveEvent) {
 			ret &= moveEvent->fireAddRemItem(item, tileItem, tile->getPosition());
 		}

--- a/src/movement.h
+++ b/src/movement.h
@@ -50,7 +50,7 @@ class MoveEvents final : public BaseEvents
 		ReturnValue onPlayerDeEquip(Player* player, Item* item, slots_t slot);
 		uint32_t onItemMove(Item* item, Tile* tile, bool isAdd);
 
-		MoveEvent* getEvent(const Tile* tile, Item* item, MoveEvent_t eventType);
+		MoveEvent* getEvent(Item* item, MoveEvent_t eventType);
 
 		bool registerLuaEvent(MoveEvent* event);
 		bool registerLuaFunction(MoveEvent* event);
@@ -71,7 +71,7 @@ class MoveEvents final : public BaseEvents
 
 		void addEvent(MoveEvent moveEvent, const Position& pos, MovePosListMap& map);
 		MoveEvent* getEvent(const Tile* tile, MoveEvent_t eventType);
-		std::vector<MoveEventList*> getEvents(const Tile* tile, MoveEvent_t eventType);
+		std::vector<MoveEventList*> getEvents(const Tile* tile);
 
 		MoveEvent* getEvent(Item* item, MoveEvent_t eventType, slots_t slot);
 

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -1604,6 +1604,10 @@ Item* Tile::getUseItem(int32_t index) const
 
 void Tile::setTrueZoneId(uint16_t zoneId)
 {
+	if (hasZoneId(zoneId))
+	{
+		return;
+	}
 	m_zoneIds.push_back(zoneId); //allows for adding zones from lua, originally adding was possible only via loading from map editor
 }
 


### PR DESCRIPTION
This removes the MoveEvent that you don't use in the code.
We remove the const Tile* that was added to getEvent.
Only add the zoneId if it doesn't already exist.

These are changes i made to my source. Otherwise it looks like you nailed it.